### PR TITLE
feat: adding .xml extension to models

### DIFF
--- a/src/SimpleSEDML/model.py
+++ b/src/SimpleSEDML/model.py
@@ -131,7 +131,7 @@ class Model:
         return self._roadrunner
 
     def _makeModelSource(self, source:Optional[str]=None)->str:
-        """Saves the model to a file. The file name is the model ID.
+        """Saves the model to a file. The file name is the model ID with .xml extension for SBML models.
         """
         if self.ref_type == cn.MODEL_ID:
             # model_ref is the ID of a previously defined model
@@ -139,7 +139,7 @@ class Model:
         if source is None:
             # Use the current directory
             source = os.getcwd()
-            source = os.path.join(source, self.id)
+            source = os.path.join(source, f"{self.id}.xml") if self.ref_type in [cn.SBML_FILE, cn.SBML_STR, cn.SBML_URL] else os.path.join(source, self.id)
         source = str(source)
         if self.is_overwrite or not os.path.exists(source):
             with open(source, "wb") as f:


### PR DESCRIPTION
### Summary
This PR ensures SBML model files are saved with `.xml` extension to clearly indicate their format and improve file type recognition.

### Changes
- Modified `_makeModelSource()` in [`model.py`](src/SimpleSEDML/model.py) to automatically add `.xml` extension for SBML model files (types: SBML_FILE, SBML_STR, SBML_URL)
- Maintained backward compatibility with existing model references
- Updated docstring to clearly document the new behavior

### Motivation
Closes #6 - Model files should have the extension "xml". This change:
- Makes file types immediately recognizable
- Follows standard conventions for SBML/XML files
- Improves compatibility with tools that expect XML extensions

### How to test
1. Create SBML models using different reference types (file, string, URL)
2. Verify saved files have `.xml` extension
3. Check that existing model loading still works
4. Test with both new and existing model files

### Risks & considerations
- Any code that assumes model files don't have extensions may need updates
- The change only affects SBML files - Antimony files still use no extension
- Existing model files without extensions will still work due to backward compatibility

### Additional information
The implementation preserves all existing functionality while adding the extension for better file type identification. The change is minimal and focused only on the file saving logic.